### PR TITLE
Fixes #5 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Ignore all .idea files and directories (PyCharm)
+.idea/

--- a/app.py
+++ b/app.py
@@ -282,10 +282,12 @@ def add_message():
     if "ttl" in request_body and request_body["ttl"]:
         try:
             ttl = int(request_body["ttl"])
-        except (ValueError, TypeError):
-            logger.warning(f"Failed to convert TTL to integer")
+            if ttl <= 0:
+                raise ValueError("The number must be a positive integer.")
+        except (ValueError, TypeError) as e:
+            logger.warning(f"Failed to convert TTL to integer: {str(e)}")
             bottle.response.status = 400
-            return {"status": "Failure", "error": ["TTL must be an integer"]}
+            return {"status": "Failure", "error": ["TTL must be a positive integer"]}
         if ttl > 604800:
             ttl = 604800
 

--- a/app.py
+++ b/app.py
@@ -277,19 +277,18 @@ def add_message():
             display_salt = True
             salt = hashlib.sha256(request_body["salt"].encode()).hexdigest()[:32]
 
-    DEFAULT_TTL = 3600
-    ttl = DEFAULT_TTL
-    if "ttl" in request_body:
-        if request_body["ttl"]:
-            try:
-                ttl = int(request_body["ttl"])
-                if ttl > 604800:
-                    ttl = 604800
-            except (ValueError, TypeError):
-                ttl = DEFAULT_TTL
-            except:
-                logger.exception(f"Unexpected error while processing TTL")
-                ttl = DEFAULT_TTL
+
+    ttl = 3600
+    if "ttl" in request_body and request_body["ttl"]:
+        try:
+            ttl = int(request_body["ttl"])
+        except (ValueError, TypeError):
+            logger.warning(f"Failed to convert TTL to integer")
+            bottle.response.status = 400
+            return {"status": "Failure", "error": ["TTL must be an integer"]}
+        if ttl > 604800:
+            ttl = 604800
+
 
     try:
         r = connect()

--- a/app.py
+++ b/app.py
@@ -277,13 +277,19 @@ def add_message():
             display_salt = True
             salt = hashlib.sha256(request_body["salt"].encode()).hexdigest()[:32]
 
-    ttl = 3600
+    DEFAULT_TTL = 3600
+    ttl = DEFAULT_TTL
     if "ttl" in request_body:
         if request_body["ttl"]:
-            if isinstance(request_body["ttl"], int):
-                ttl = request_body["ttl"]
+            try:
+                ttl = int(request_body["ttl"])
                 if ttl > 604800:
                     ttl = 604800
+            except (ValueError, TypeError):
+                ttl = DEFAULT_TTL
+            except:
+                logger.exception(f"Unexpected error while processing TTL")
+                ttl = DEFAULT_TTL
 
     try:
         r = connect()

--- a/views/index.html
+++ b/views/index.html
@@ -79,7 +79,7 @@
                 <span>TTL <i>(Optional)</i></span>
             </div>
             <div class="input-container space-start">
-                <input class="input-field small" id="ttl-input" type="number" value="{{ttl}}"/>
+                <input class="input-field small" id="ttl-input" type="text" value="{{ttl}}"/>
                 <button class="hover-target" ><i class="fas fa-info-circle"></i></button>
                 <div class="hover-popup input-popup">Time to live for the message, default is 3600 and max is 604800 (7days). The value entered is an integer in seconds</div>
                 <button class="input-button" id="submit-button" type="button">Submit</button>

--- a/views/index.html
+++ b/views/index.html
@@ -79,7 +79,7 @@
                 <span>TTL <i>(Optional)</i></span>
             </div>
             <div class="input-container space-start">
-                <input class="input-field small" id="ttl-input" type="text" value="{{ttl}}"/>
+                <input class="input-field small" id="ttl-input" type="number" value="{{ttl}}"/>
                 <button class="hover-target" ><i class="fas fa-info-circle"></i></button>
                 <div class="hover-popup input-popup">Time to live for the message, default is 3600 and max is 604800 (7days). The value entered is an integer in seconds</div>
                 <button class="input-button" id="submit-button" type="button">Submit</button>


### PR DESCRIPTION
Fixes #5 by converting the expected string to an integer.
Reset to default TTL when encountering reasonable exceptions.
Log exception and reset to default TTL when encountering unexpected exceptions.